### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Android Awesome Material
+# Android Awesome Material
 
 A library for Android that makes it super easy for developers to incorporate material design and bootstrap buttons with icons into their apps, or simple icon themed TextViews. Includes three separate font sets to chose from for icons; Font Awesome, Material Design Iconic Font, and Pixeden Stroke Icon Font Set. Also allows to chose between bootstrap or material design colour themes. Scroll down for pictures in use :-)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
